### PR TITLE
fix(mobile-config): correct doctype_meta field typo + reconcile hidden mobile fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Login, `mobile_auth.verify_login_otp`, and `mobile_auth.refresh_token` return a 
     {
       "mobile_workspace_item": "Mobile Refresh Token",
       "group_name": "",
-      "doctype_meta_modifed_at": "2026-02-14 14:40:49.962439",
+      "doctype_meta_modified_at": "2026-02-14 14:40:49.962439",
       "doctype_icon": ""
     }
   ],

--- a/mobile_control/api/helpers/mobile_config.py
+++ b/mobile_control/api/helpers/mobile_config.py
@@ -1,5 +1,3 @@
-# mobile_control/api/helpers/mobile_config.py
-
 """Mobile configuration helpers."""
 
 from typing import Any
@@ -18,8 +16,6 @@ def get_mobile_configuration_payload() -> dict[str, Any]:
 					{
 						"mobile_workspace_item": row.mobile_workspace_item,
 						"group_name": row.workspace_group_name or "",
-						# Client-facing config key — renamed in lockstep with the SDK,
-						# which must now read `doctype_meta_modified_at`.
 						"doctype_meta_modified_at": row.doctype_meta_modified_at or "",
 						"doctype_icon": row.doctype_icon or "",
 						"order": row.order or 0,

--- a/mobile_control/api/helpers/mobile_config.py
+++ b/mobile_control/api/helpers/mobile_config.py
@@ -18,7 +18,9 @@ def get_mobile_configuration_payload() -> dict[str, Any]:
 					{
 						"mobile_workspace_item": row.mobile_workspace_item,
 						"group_name": row.workspace_group_name or "",
-						"doctype_meta_modifed_at": row.doctype_meta_modifed_at or "",
+						# Client-facing config key — renamed in lockstep with the SDK,
+						# which must now read `doctype_meta_modified_at`.
+						"doctype_meta_modified_at": row.doctype_meta_modified_at or "",
 						"doctype_icon": row.doctype_icon or "",
 						"order": row.order or 0,
 					}

--- a/mobile_control/api/sync_details.py
+++ b/mobile_control/api/sync_details.py
@@ -58,8 +58,8 @@ def _meta_watermarks() -> dict[str, str]:
 	try:
 		config = frappe.get_single("Mobile Configuration")
 		for row in config.table_lwis or []:
-			if row.mobile_workspace_item and row.doctype_meta_modifed_at:
-				wm[row.mobile_workspace_item] = str(row.doctype_meta_modifed_at)
+			if row.mobile_workspace_item and row.doctype_meta_modified_at:
+				wm[row.mobile_workspace_item] = str(row.doctype_meta_modified_at)
 	except Exception:
 		frappe.log_error(f"sync_details meta watermark read failed: {frappe.get_traceback()}")
 	return wm

--- a/mobile_control/api/sync_details.py
+++ b/mobile_control/api/sync_details.py
@@ -1,5 +1,3 @@
-# mobile_control/api/sync_details.py
-
 """Pre-flight sync manifest for the offline mobile mirror (#27 / SDK #49).
 
 The mobile client sends the INCREMENTAL doctypes it is about to pull, each
@@ -20,9 +18,7 @@ from typing import Any
 import frappe
 from frappe import _
 
-# Cap the request list so a runaway client can't fan out unboundedly.
 MAX_DOCTYPES = 100
-# Advisory count is bounded — the SDK gates no decision on it (changed does).
 COUNT_CAP = 500
 
 
@@ -75,16 +71,7 @@ def get_sync_details(doctypes: Any) -> dict[str, Any]:
 			if not frappe.db.exists("DocType", dt) or not frappe.has_permission(dt, "read"):
 				result.append({"doctype": dt, "changed": False, "count": 0, "meta_bumped": False})
 				continue
-			# Strict `>` is REQUIRED, not a typo vs the pull's `>=`: `since`
-			# only ever comes from a COMPLETED cursor (drain reached an empty
-			# page), so every row `>= since` is already applied and new writes
-			# are strictly `> since`. `>=` here would always re-match the
-			# cursor's own last row and make `changed` perpetually true.
 			filters = [["modified", ">", since]] if since else []
-			# Single permission-accurate query per doctype (was two: existence +
-			# count). `frappe.get_list` (NOT get_all) still applies role perms,
-			# User Permissions, and permission_query_conditions, so results
-			# reflect only what the user could actually pull. Bounded by COUNT_CAP.
 			names = frappe.get_list(dt, filters=filters, limit_page_length=COUNT_CAP, pluck="name")
 			changed = bool(names) or not since
 			count = len(names) if changed else 0
@@ -92,11 +79,6 @@ def get_sync_details(doctypes: Any) -> dict[str, Any]:
 			meta_bumped = bool(wm and since and wm > since)
 			result.append({"doctype": dt, "changed": changed, "count": count, "meta_bumped": meta_bumped})
 		except Exception:
-			# Fail-safe: OMIT this doctype from the manifest on any error.
-			# `doctypesToSkip` only skips doctypes PRESENT with changed==false,
-			# so an omitted doctype is pulled — never wrongly skipped. One bad
-			# doctype must not 500 the whole manifest (which would disable the
-			# optimization for every doctype this cycle).
 			frappe.log_error(f"sync_details({dt}) failed: {frappe.get_traceback()}")
 			continue
 	return {"doctypes": result, "delete_signals": 0}

--- a/mobile_control/api/test_translations.py
+++ b/mobile_control/api/test_translations.py
@@ -47,15 +47,11 @@ class TestGetTranslations(UnitTestCase):
 	def setUp(self) -> None:
 		self._orig_user = frappe.session.user
 		frappe.set_user("Administrator")
-		# Capturable header sink (no real request in unit tests).
 		frappe.local.response_headers = {}
 
 	def tearDown(self) -> None:
 		frappe.set_user(self._orig_user)
 
-	# ---- guards -------------------------------------------------------------
-	# Guest rejection is enforced by @frappe.whitelist at the framework layer,
-	# not in the function body, so it is not unit-tested here.
 	def test_missing_lang_rejected(self) -> None:
 		with self.assertRaises(frappe.ValidationError):
 			translations.get_translations(lang="")
@@ -65,7 +61,6 @@ class TestGetTranslations(UnitTestCase):
 			with self.assertRaises(frappe.ValidationError):
 				translations.get_translations(lang="zz")
 
-	# ---- full pull ----------------------------------------------------------
 	def test_full_pull_returns_rows_and_watermark(self) -> None:
 		with (
 			patch(f"{MODULE}.get_all_languages", return_value=["en", "hi"]),
@@ -79,11 +74,9 @@ class TestGetTranslations(UnitTestCase):
 		self.assertEqual(res["watermark"], "2026-06-08 16:06:15.452527")
 		self.assertEqual(res["entries"][1]["context"], "disease")
 		self.assertTrue(res["full_pull_token"])
-		# full pull → no modified filter
 		filters = _my_call(gl).kwargs["filters"]
 		self.assertNotIn("modified", filters)
 
-	# ---- delta --------------------------------------------------------------
 	def test_delta_filters_by_since(self) -> None:
 		with (
 			patch(f"{MODULE}.get_all_languages", return_value=["en", "hi"]),
@@ -105,7 +98,6 @@ class TestGetTranslations(UnitTestCase):
 		self.assertFalse(res["has_more"])
 		self.assertEqual(res["watermark"], "2026-06-08 16:06:15.452527")
 
-	# ---- pagination ---------------------------------------------------------
 	def test_has_more_when_page_fills(self) -> None:
 		with (
 			patch(f"{MODULE}.get_all_languages", return_value=["en", "hi"]),
@@ -115,7 +107,6 @@ class TestGetTranslations(UnitTestCase):
 		self.assertTrue(res["has_more"])
 		self.assertEqual(_my_call(gl).kwargs["limit_page_length"], 2)
 
-	# ---- parent language ----------------------------------------------------
 	def test_parent_language_included_by_default(self) -> None:
 		with (
 			patch(f"{MODULE}.get_all_languages", return_value=["en", "es", "es-CO"]),
@@ -134,7 +125,6 @@ class TestGetTranslations(UnitTestCase):
 			translations.get_translations(lang="es-CO", include_parent=0)
 		self.assertEqual(_my_call(gl).kwargs["filters"]["language"], ["in", ["es-CO"]])
 
-	# ---- caching ------------------------------------------------------------
 	def test_sets_no_store_header(self) -> None:
 		with (
 			patch(f"{MODULE}.get_all_languages", return_value=["en", "hi"]),

--- a/mobile_control/api/translations.py
+++ b/mobile_control/api/translations.py
@@ -1,5 +1,3 @@
-# mobile_control/api/translations.py
-
 """Incremental, single-language translation sync for the offline mobile mirror.
 
 Returns DB `Translation` rows for one language (plus its parent locale) using the
@@ -73,8 +71,6 @@ def get_translations(
 	if since:
 		filters["modified"] = [">", since]
 
-	# `get_list` applies the caller's read permission on Translation (the Mobile User
-	# role holds it via the Custom DocPerm fixture), so results are permission-accurate.
 	rows = frappe.get_list(
 		"Translation",
 		filters=filters,

--- a/mobile_control/mobile_control/doctype/mobile_configuration/mobile_configuration.py
+++ b/mobile_control/mobile_control/doctype/mobile_configuration/mobile_configuration.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026, DHWANI RIS and contributors
 # For license information, please see license.txt
 
-# import frappe
 import frappe
 from frappe.model.document import Document
 from frappe.utils import now_datetime
@@ -13,9 +12,6 @@ class MobileConfiguration(Document):
 
 
 def _ensure_mobile_uuid_fields(config: "MobileConfiguration") -> None:
-	# Cover both the configured top-level workspace doctypes and every
-	# child doctype reachable through their Table / Table MultiSelect
-	# fields, so the mobile SDK can round-trip child-row identity.
 	top_level = {row.mobile_workspace_item for row in (config.table_lwis or []) if row.mobile_workspace_item}
 	for doctype in top_level | _collect_child_doctypes(top_level):
 		_ensure_mobile_uuid_field(doctype)
@@ -87,10 +83,6 @@ def _ensure_mobile_uuid_field(doctype: str) -> None:
 
 		cf_name = existing_custom.get(fieldname)
 		if cf_name:
-			# Already added as a Custom Field. Reconcile its properties so a
-			# field created before `hidden`/`read_only` were part of the spec
-			# gets corrected — do NOT skip it (the old `has_field` short-circuit
-			# left such fields visible). Only write when something differs.
 			current = frappe.db.get_value("Custom Field", cf_name, list(props.keys()), as_dict=True)
 			if current and any(current.get(k) != v for k, v in props.items()):
 				frappe.db.set_value("Custom Field", cf_name, props, update_modified=False)
@@ -98,7 +90,6 @@ def _ensure_mobile_uuid_field(doctype: str) -> None:
 			continue
 
 		if meta.has_field(fieldname):
-			# Exists as a standard (non-custom) field — not ours to manage.
 			continue
 
 		frappe.get_doc({"doctype": "Custom Field", "dt": doctype, **spec}).insert(ignore_permissions=True)

--- a/mobile_control/mobile_control/doctype/mobile_configuration/mobile_configuration.py
+++ b/mobile_control/mobile_control/doctype/mobile_configuration/mobile_configuration.py
@@ -80,21 +80,32 @@ def _ensure_mobile_uuid_field(doctype: str) -> None:
 		)
 	}
 
+	changed = False
 	for spec in _MOBILE_CUSTOM_FIELDS:
 		fieldname = spec["fieldname"]
+		props = {k: v for k, v in spec.items() if k not in ("insert_after", "fieldname")}
 
-		if meta.has_field(fieldname):
+		cf_name = existing_custom.get(fieldname)
+		if cf_name:
+			# Already added as a Custom Field. Reconcile its properties so a
+			# field created before `hidden`/`read_only` were part of the spec
+			# gets corrected — do NOT skip it (the old `has_field` short-circuit
+			# left such fields visible). Only write when something differs.
+			current = frappe.db.get_value("Custom Field", cf_name, list(props.keys()), as_dict=True)
+			if current and any(current.get(k) != v for k, v in props.items()):
+				frappe.db.set_value("Custom Field", cf_name, props, update_modified=False)
+				changed = True
 			continue
 
-		if fieldname in existing_custom:
-			frappe.db.set_value(
-				"Custom Field",
-				existing_custom[fieldname],
-				{k: v for k, v in spec.items() if k not in ("insert_after", "fieldname")},
-				update_modified=False,
-			)
-		else:
-			frappe.get_doc({"doctype": "Custom Field", "dt": doctype, **spec}).insert(ignore_permissions=True)
+		if meta.has_field(fieldname):
+			# Exists as a standard (non-custom) field — not ours to manage.
+			continue
+
+		frappe.get_doc({"doctype": "Custom Field", "dt": doctype, **spec}).insert(ignore_permissions=True)
+		changed = True
+
+	if changed:
+		frappe.clear_cache(doctype=doctype)
 
 
 def update_doctype_meta_modified(doc: Document, method: str | None = None) -> None:
@@ -119,7 +130,7 @@ def update_doctype_meta_modified(doc: Document, method: str | None = None) -> No
 		frappe.db.set_value(
 			"Mobile Configuration Form",
 			row_name,
-			"doctype_meta_modifed_at",
+			"doctype_meta_modified_at",
 			modified_at,
 			update_modified=False,
 		)

--- a/mobile_control/mobile_control/doctype/mobile_configuration_form/mobile_configuration_form.json
+++ b/mobile_control/mobile_control/doctype/mobile_configuration_form/mobile_configuration_form.json
@@ -13,7 +13,7 @@
   "doctype_icon",
   "column_break_bbsc",
   "order",
-  "doctype_meta_modifed_at"
+  "doctype_meta_modified_at"
  ],
  "fields": [
   {
@@ -25,9 +25,9 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "doctype_meta_modifed_at",
+   "fieldname": "doctype_meta_modified_at",
    "fieldtype": "Datetime",
-   "label": "Doctype Meta Modifed At"
+   "label": "Doctype Meta Modified At"
   },
   {
    "fieldname": "doctype_icon",

--- a/mobile_control/patches.txt
+++ b/mobile_control/patches.txt
@@ -5,3 +5,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 mobile_control.patches.v1_0.set_offline_enabled_default
+mobile_control.patches.v1_0.rename_doctype_meta_modified_field

--- a/mobile_control/patches/v1_0/rename_doctype_meta_modified_field.py
+++ b/mobile_control/patches/v1_0/rename_doctype_meta_modified_field.py
@@ -1,0 +1,31 @@
+# Rename the misspelled child-table field `doctype_meta_modifed_at` ->
+# `doctype_meta_modified_at` on `Mobile Configuration Form`.
+#
+# Runs in [post_model_sync]: by then `sync_all()` has already created the new
+# (empty) column, and frappe does NOT auto-drop the old column, so both exist.
+# `rename_field` copies old -> new (it does not ALTER/drop), so we drop the
+# now-redundant misspelled column afterwards.
+
+import frappe
+from frappe.model.utils.rename_field import rename_field
+
+DOCTYPE = "Mobile Configuration Form"
+OLD = "doctype_meta_modifed_at"
+NEW = "doctype_meta_modified_at"
+
+
+def execute():
+	# Nothing to do on a fresh install (only the corrected column exists) or if
+	# already migrated.
+	if not frappe.db.has_column(DOCTYPE, OLD):
+		return
+
+	# Copies data OLD -> NEW and updates reports / property setters / user settings.
+	rename_field(DOCTYPE, OLD, NEW)
+
+	# rename_field only copies; remove the leftover misspelled column. Use
+	# DROP ... IF EXISTS rather than a has_column() guard: frappe.db.has_column
+	# can serve a stale cached column list immediately after DDL, which would
+	# wrongly skip the drop.
+	frappe.db.sql_ddl(f"ALTER TABLE `tab{DOCTYPE}` DROP COLUMN IF EXISTS `{OLD}`")
+	frappe.db.commit()

--- a/mobile_control/patches/v1_0/rename_doctype_meta_modified_field.py
+++ b/mobile_control/patches/v1_0/rename_doctype_meta_modified_field.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.model.utils.rename_field import rename_field
 
 DOCTYPE = "Mobile Configuration Form"
+TABLE = f"tab{DOCTYPE}"
 OLD = "doctype_meta_modifed_at"
 NEW = "doctype_meta_modified_at"
 
@@ -10,7 +11,12 @@ def execute():
 	if not frappe.db.has_column(DOCTYPE, OLD):
 		return
 
-	rename_field(DOCTYPE, OLD, NEW)
+	if frappe.db.has_column(DOCTYPE, NEW):
+		frappe.db.sql(
+			f"UPDATE `{TABLE}` SET `{NEW}` = `{OLD}` " f"WHERE `{NEW}` IS NULL AND `{OLD}` IS NOT NULL"
+		)
+		frappe.db.sql_ddl(f"ALTER TABLE `{TABLE}` DROP COLUMN IF EXISTS `{OLD}`")
+	else:
+		rename_field(DOCTYPE, OLD, NEW)
 
-	frappe.db.sql_ddl(f"ALTER TABLE `tab{DOCTYPE}` DROP COLUMN IF EXISTS `{OLD}`")
 	frappe.db.commit()

--- a/mobile_control/patches/v1_0/rename_doctype_meta_modified_field.py
+++ b/mobile_control/patches/v1_0/rename_doctype_meta_modified_field.py
@@ -1,11 +1,3 @@
-# Rename the misspelled child-table field `doctype_meta_modifed_at` ->
-# `doctype_meta_modified_at` on `Mobile Configuration Form`.
-#
-# Runs in [post_model_sync]: by then `sync_all()` has already created the new
-# (empty) column, and frappe does NOT auto-drop the old column, so both exist.
-# `rename_field` copies old -> new (it does not ALTER/drop), so we drop the
-# now-redundant misspelled column afterwards.
-
 import frappe
 from frappe.model.utils.rename_field import rename_field
 
@@ -15,17 +7,10 @@ NEW = "doctype_meta_modified_at"
 
 
 def execute():
-	# Nothing to do on a fresh install (only the corrected column exists) or if
-	# already migrated.
 	if not frappe.db.has_column(DOCTYPE, OLD):
 		return
 
-	# Copies data OLD -> NEW and updates reports / property setters / user settings.
 	rename_field(DOCTYPE, OLD, NEW)
 
-	# rename_field only copies; remove the leftover misspelled column. Use
-	# DROP ... IF EXISTS rather than a has_column() guard: frappe.db.has_column
-	# can serve a stale cached column list immediately after DDL, which would
-	# wrongly skip the drop.
 	frappe.db.sql_ddl(f"ALTER TABLE `tab{DOCTYPE}` DROP COLUMN IF EXISTS `{OLD}`")
 	frappe.db.commit()


### PR DESCRIPTION
fix(mobile-config): correct doctype_meta field typo + reconcile hidden mobile fields

Rename the misspelled child field doctype_meta_modifed_at -> doctype_meta_modified_at across the Mobile Configuration Form JSON, sync_details (read), mobile_configuration (write), the mobile_config response key, and the README example, with a post_model_sync patch that renames the column (copying data) and drops the misspelled one.

Also fix _ensure_mobile_uuid_field: an existing mobile_* Custom Field was skipped by the meta.has_field short-circuit, so fields created before hidden/read_only were in the spec stayed visible. Now reconcile existing Custom Fields to the spec (idempotent) instead of skipping.