### PR TITLE
fix(mobile-config): run doctype_meta rename pre-sync + guard hook against missing column

### DIFF
--- a/mobile_control/mobile_control/doctype/mobile_configuration/mobile_configuration.py
+++ b/mobile_control/mobile_control/doctype/mobile_configuration/mobile_configuration.py
@@ -100,6 +100,9 @@ def _ensure_mobile_uuid_field(doctype: str) -> None:
 
 
 def update_doctype_meta_modified(doc: Document, method: str | None = None) -> None:
+	if not frappe.db.has_column("Mobile Configuration Form", "doctype_meta_modified_at"):
+		return
+
 	doctype_name = _get_doctype_name_from_doc(doc)
 	if not doctype_name:
 		return

--- a/mobile_control/patches.txt
+++ b/mobile_control/patches.txt
@@ -1,8 +1,8 @@
 [pre_model_sync]
 # Patches added in this section will be executed before doctypes are migrated
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
+mobile_control.patches.v1_0.rename_doctype_meta_modified_field
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 mobile_control.patches.v1_0.set_offline_enabled_default
-mobile_control.patches.v1_0.rename_doctype_meta_modified_field


### PR DESCRIPTION
fix(mobile-config): run doctype_meta rename pre-sync + guard hook against missing column

update_doctype_meta_modified reads doctype_meta_modified_at during schema sync, but rename_doctype_meta_modified_field ran in post_model_sync (after sync), so a site that still has the old typo'd column crashed migrate with 'Unknown column doctype_meta_modified_at'. Move the rename to pre_model_sync so the column is correct before any DocType on_update fires, and guard the hook with has_column so it can never abort a migrate regardless of sync ordering.