### PR TITLE
feat: mobile-config — emit mobile_doctype + derive meta-refresh signal [review-only]

### DIFF
--- a/mobile_control/api/helpers/mobile_config.py
+++ b/mobile_control/api/helpers/mobile_config.py
@@ -7,6 +7,29 @@ from typing import Any
 import frappe
 
 
+def _meta_modified_for(form_doctype: str, fallback: Any) -> str:
+	"""Derive the mobile meta-refresh signal for a form: MAX(modified) across its
+	DocType + child DocTypes + Property Setters + Custom Fields. Customize-Form
+	artifacts don't bump DocType.modified, so without this the signal is stale.
+
+	Reuses the same helper that stamps the meta response in rf_mis (single source of
+	truth, so the device's cached `modified` converges with this signal and it does
+	not re-fetch every launch). Falls back to the manually-stored value if rf_mis is
+	unavailable or the form doctype is missing.
+	"""
+	if not form_doctype:
+		return fallback or ""
+	try:
+		from rf_mis.rf_mis.api.meta_override import compute_meta_modified
+
+		derived = compute_meta_modified(form_doctype)
+		if derived:
+			return derived
+	except Exception:
+		pass
+	return fallback or ""
+
+
 def get_mobile_configuration_payload() -> dict[str, Any]:
 	"""Get mobile configuration and app status from Single doctype."""
 	try:
@@ -16,9 +39,16 @@ def get_mobile_configuration_payload() -> dict[str, Any]:
 			for row in config.table_lwis:
 				configuration.append(
 					{
+						# `mobile_doctype` is the key the SDK actually reads
+						# (mobile_form_name.dart). `mobile_workspace_item` is kept for
+						# server-side consumers (permissions.py). Both carry the form
+						# doctype name.
+						"mobile_doctype": row.mobile_workspace_item,
 						"mobile_workspace_item": row.mobile_workspace_item,
 						"group_name": row.workspace_group_name or "",
-						"doctype_meta_modifed_at": row.doctype_meta_modifed_at or "",
+						"doctype_meta_modifed_at": _meta_modified_for(
+							row.mobile_workspace_item, row.doctype_meta_modifed_at
+						),
 						"doctype_icon": row.doctype_icon or "",
 						"order": row.order or 0,
 					}


### PR DESCRIPTION
## What & why

The **mobile_control** half of the mobile meta-refresh fix (companion: rf_mis PR dhwani-ris/frappe_rf_mis#59, + a project-end SDK change). Server field changes (hide / new / relabel) weren't reaching the app without a cache clear.

## This PR (`api/helpers/mobile_config.py`, single commit `79a99d0`)

- Emit **`mobile_doctype`** in the config payload — the key the SDK actually reads (`mobile_form_name.dart`). The server only emitted `mobile_workspace_item`, so the signal never registered. `mobile_workspace_item` is kept for the server-side consumers (`permissions.py`).
- Derive **`doctype_meta_modifed_at`** = `MAX(modified)` across the form + its child doctypes + Property Setters + Custom Fields, by reusing `rf_mis.rf_mis.api.meta_override.compute_meta_modified` (single source of truth with the meta stamp). Safe try/except fallback to the stored value.

## Tech debt (flagged per review)

`mobile_control` now imports a helper from `rf_mis` — an **inverted dependency** (generic app → site app). Acceptable for now since `mobile_control` is feature-branch-only and ships alongside rf_mis; long-term the helper should move to a generic layer or be duplicated.

## Status

- **Review-only** — `mobile_control` is feature-branch-only and not merged until project end. Base is `develop` purely to give a clean single-commit diff; **do not merge to develop**. Retarget if you'd prefer a different base.
- Validated end-to-end on device (child column hidden → gone on Sync + reopen, no cache clear). Helper unit-tested in the rf_mis PR.

📄 Full write-up + proof: https://claude.ai/code/artifact/bf2acb21-313f-4565-bb29-8424134fbda4
