### PR TITLE
fix(auth): return refresh_token payload top-level with correct HTTP codes

### DIFF
--- a/mobile_control/api/api_auth.py
+++ b/mobile_control/api/api_auth.py
@@ -324,7 +324,7 @@ def verify_mobile_otp(tmp_id: str, otp: str) -> None:
 @rate_limit(
 	key="refresh_token", limit=get_mobile_login_ratelimit, seconds=60 * 60
 )  # comment out for now to avoid rate limiting while testing
-def refresh_token(refresh_token: str) -> dict[str, str]:
+def refresh_token(refresh_token: str) -> None:
 	"""Refresh access token using refresh token."""
 	try:
 		token_doc = get_valid_refresh_token_doc(refresh_token)
@@ -338,20 +338,34 @@ def refresh_token(refresh_token: str) -> dict[str, str]:
 		mobile_config = payload.get("configuration", [])
 		offline_enabled = bool(payload.get("offline_enabled", False))
 
-		return build_auth_response(
-			user_doc,
-			access_token,
-			refresh_token=new_refresh_token,
-			message=_("Token refreshed"),
-			mobile_config=mobile_config,
-			offline_enabled=offline_enabled,
+		# Write tokens to the top level of the response (same as `login`).
+		# Frappe wraps a whitelisted function's *return* value under a top-level
+		# `message` key (frappe/handler.py: `frappe.response["message"] = data`),
+		# so `return build_auth_response(...)` would nest access_token/refresh_token
+		# under `message` — inconsistent with `login`, which uses
+		# `frappe.local.response.update(...)`. Mobile clients read the tokens at
+		# the top level, so mirror `login` here.
+		frappe.local.response.update(
+			build_auth_response(
+				user_doc,
+				access_token,
+				refresh_token=new_refresh_token,
+				message=_("Token refreshed"),
+				mobile_config=mobile_config,
+				offline_enabled=offline_enabled,
+			)
 		)
 	except frappe.AuthenticationError:
-		frappe.throw(_("Invalid or expired refresh token"))
+		# Invalid/expired refresh token → 401 so the client re-authenticates
+		# (AuthenticationError.http_status_code == 401). A bare frappe.throw would
+		# raise ValidationError (417), which clients treat as a param error.
+		frappe.throw(_("Invalid or expired refresh token"), frappe.AuthenticationError)
 	except frappe.PermissionError:
-		frappe.throw(_("Not allowed to use mobile app"))
+		# Not allowed on mobile → 403 (PermissionError.http_status_code == 403).
+		frappe.throw(_("Not allowed to use mobile app"), frappe.PermissionError)
 	except frappe.ValidationError:
-		frappe.throw(_("Invalid request parameters"))
+		# Missing/invalid parameters → 417 (Frappe default for ValidationError).
+		frappe.throw(_("Invalid request parameters"), frappe.ValidationError)
 	except Exception as e:
 		frappe.log_error(f"Mobile Refresh Token Error: {e}")
 		frappe.throw(_("Failed to refresh token. Please try again."))

--- a/mobile_control/api/test_refresh_token.py
+++ b/mobile_control/api/test_refresh_token.py
@@ -102,12 +102,8 @@ class TestRefreshTokenEndpoint(IntegrationTestCase):
 		raw = create_refresh_token(self.mobile_user, device_id="dev-3", user_agent="ua-3")
 		# Match the exact row we just created by its stored hash (robust against
 		# same-second `creation` ties with tokens from earlier tests).
-		token_name = frappe.get_value(
-			"Mobile Refresh Token", {"token_hash": hash_refresh_token(raw)}, "name"
-		)
-		frappe.db.set_value(
-			"Mobile Refresh Token", token_name, "expires_at", add_days(now_datetime(), -1)
-		)
+		token_name = frappe.get_value("Mobile Refresh Token", {"token_hash": hash_refresh_token(raw)}, "name")
+		frappe.db.set_value("Mobile Refresh Token", token_name, "expires_at", add_days(now_datetime(), -1))
 		self._reset_response()
 
 		with self.assertRaises(frappe.AuthenticationError) as cm:

--- a/mobile_control/api/test_refresh_token.py
+++ b/mobile_control/api/test_refresh_token.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days
+from frappe.utils import now_datetime
+from mobile_control.api import api_auth
+from mobile_control.api.helpers.refresh_token import create_refresh_token
+from mobile_control.api.helpers.refresh_token import hash_refresh_token
+from mobile_control.api.helpers.user_auth import ensure_api_credentials
+
+MOBILE_USER_EMAIL = "refresh-mobile@example.com"
+NON_MOBILE_USER_EMAIL = "refresh-plain@example.com"
+
+
+def _ensure_role(role: str) -> None:
+	if not frappe.db.exists("Role", role):
+		frappe.get_doc({"doctype": "Role", "role_name": role}).insert(ignore_permissions=True)
+
+
+def _make_user(email: str, mobile: bool) -> frappe.model.document.Document:
+	if frappe.db.exists("User", email):
+		user = frappe.get_doc("User", email)
+	else:
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Refresh",
+				"send_welcome_email": 0,
+				"enabled": 1,
+			}
+		).insert(ignore_permissions=True)
+	if mobile:
+		_ensure_role("Mobile User")
+		user.add_roles("Mobile User")
+	ensure_api_credentials(user)
+	return frappe.get_doc("User", email)
+
+
+class TestRefreshTokenEndpoint(IntegrationTestCase):
+	"""Regression tests for api_auth.refresh_token (PR #37).
+
+	Covers the two behaviours the fix introduced:
+	  1. Tokens are written to the TOP LEVEL of frappe.local.response (mirroring
+	     `login`), not returned as a dict that Frappe would nest under `message`.
+	  2. Failures raise typed exceptions so the correct HTTP status propagates
+	     (AuthenticationError -> 401, PermissionError -> 403, ValidationError -> 417).
+	"""
+
+	@classmethod
+	def setUpClass(cls) -> None:
+		super().setUpClass()
+		cls.mobile_user = _make_user(MOBILE_USER_EMAIL, mobile=True)
+		cls.plain_user = _make_user(NON_MOBILE_USER_EMAIL, mobile=False)
+
+	def _reset_response(self) -> None:
+		for key in ("access_token", "refresh_token", "message"):
+			frappe.local.response.pop(key, None)
+
+	# --- success: tokens land top-level (the core regression guard) ---------
+
+	def test_refresh_returns_tokens_at_top_level(self) -> None:
+		raw = create_refresh_token(self.mobile_user, device_id="dev-1", user_agent="ua-1")
+		self._reset_response()
+
+		result = api_auth.refresh_token(raw)
+
+		# The endpoint writes to frappe.local.response and returns None, so Frappe
+		# does not wrap the payload under `message`.
+		self.assertIsNone(result)
+		self.assertIn("access_token", frappe.local.response)
+		self.assertTrue(frappe.local.response["access_token"])
+		self.assertIn("refresh_token", frappe.local.response)
+		# Rotation: the returned refresh token is a fresh one, not the used token.
+		self.assertNotEqual(frappe.local.response["refresh_token"], raw)
+		# `message` is a plain label sitting alongside the tokens, NOT a wrapper
+		# dict containing them (the old bug nested everything under `message`).
+		self.assertEqual(frappe.local.response.get("message"), "Token refreshed")
+
+	def test_refresh_rotates_old_token(self) -> None:
+		raw = create_refresh_token(self.mobile_user, device_id="dev-2", user_agent="ua-2")
+		self._reset_response()
+
+		api_auth.refresh_token(raw)
+
+		# Re-using the now-rotated token must fail as an auth error.
+		self._reset_response()
+		with self.assertRaises(frappe.AuthenticationError) as cm:
+			api_auth.refresh_token(raw)
+		self.assertEqual(cm.exception.http_status_code, 401)
+
+	# --- error mapping: correct HTTP status codes ---------------------------
+
+	def test_invalid_refresh_token_returns_401(self) -> None:
+		self._reset_response()
+		with self.assertRaises(frappe.AuthenticationError) as cm:
+			api_auth.refresh_token("this-token-does-not-exist")
+		self.assertEqual(cm.exception.http_status_code, 401)
+
+	def test_expired_refresh_token_returns_401(self) -> None:
+		raw = create_refresh_token(self.mobile_user, device_id="dev-3", user_agent="ua-3")
+		# Match the exact row we just created by its stored hash (robust against
+		# same-second `creation` ties with tokens from earlier tests).
+		token_name = frappe.get_value(
+			"Mobile Refresh Token", {"token_hash": hash_refresh_token(raw)}, "name"
+		)
+		frappe.db.set_value(
+			"Mobile Refresh Token", token_name, "expires_at", add_days(now_datetime(), -1)
+		)
+		self._reset_response()
+
+		with self.assertRaises(frappe.AuthenticationError) as cm:
+			api_auth.refresh_token(raw)
+		self.assertEqual(cm.exception.http_status_code, 401)
+
+	def test_user_without_mobile_role_returns_403(self) -> None:
+		raw = create_refresh_token(self.plain_user, device_id="dev-4", user_agent="ua-4")
+		self._reset_response()
+
+		with self.assertRaises(frappe.PermissionError) as cm:
+			api_auth.refresh_token(raw)
+		self.assertEqual(cm.exception.http_status_code, 403)
+
+	def test_missing_refresh_token_returns_417(self) -> None:
+		self._reset_response()
+		with self.assertRaises(frappe.ValidationError) as cm:
+			api_auth.refresh_token("")
+		self.assertEqual(cm.exception.http_status_code, 417)


### PR DESCRIPTION
mobile_auth.refresh_token returned build_auth_response() directly. Frappe wraps a whitelisted function's return value under the top-level `message` key (frappe/handler.py: frappe.response["message"] = data), unlike login which writes fields via frappe.local.response.update(). Mobile clients read access_token / refresh_token at the top level, so token refresh silently failed and users were logged out when the access token expired.

- Mirror login: write the payload via frappe.local.response.update(...) so tokens land top-level.
- Raise correct exception types so proper HTTP codes propagate instead of a bare frappe.throw (ValidationError -> 417): AuthenticationError -> 401 (invalid/expired refresh token, client should re-authenticate), PermissionError -> 403.
# Status codes handled by refresh_token

| Scenario | Code path | Exception raised | HTTP | Verified at |
|----------|-----------|------------------|------|-------------|
| Success | tokens written to `frappe.local.response`, returns None | – | 200 | Frappe default when response has data |
| Invalid / expired refresh token | `except frappe.AuthenticationError` | `frappe.AuthenticationError` | 401 | `exceptions.py:32-33` |
| User not allowed on mobile | `except frappe.PermissionError` | `frappe.PermissionError` | 403 | `exceptions.py:40-41` |
| Missing / invalid parameters | `except frappe.ValidationError` | `frappe.ValidationError` | 417 | `exceptions.py:24-25` |
| Any other unexpected error | `except Exception` - logs, then bare `frappe.throw()` | `frappe.ValidationError` (default exc) | 417 | `messages.py:139` default + `exceptions.py:24` |